### PR TITLE
+ rubynext.y: support ivars/gvars as p_variables

### DIFF
--- a/lib/parser/ruby-next/builder.rb
+++ b/lib/parser/ruby-next/builder.rb
@@ -11,6 +11,13 @@ module Parser
           send_map(receiver, dot_t, selector_t, nil, [], nil))
     end
 
+    def match_var(var)
+      return super(var) unless var.is_a?(::Parser::AST::Node)
+
+      n(:match_var, [ var ],
+        var_send_map(var))
+    end
+
     def check_reserved_for_numparam(name, loc)
       # We don't want to raise SyntaxError, 'cause we want to use _x vars for older Rubies.
       # The exception should be raised by Ruby itself for versions supporting numbered parameters

--- a/lib/parser/rubynext.y
+++ b/lib/parser/rubynext.y
@@ -2124,23 +2124,13 @@ opt_block_args_tail:
                     {
                       result = [ *val[0], val[1] ]
                     }
-                | p_args_head tSTAR tIDENTIFIER
+                | p_args_head p_rest
                     {
-                      match_rest = @builder.match_rest(val[1], val[2])
-                      result = [ *val[0], match_rest ]
+                      result = [ *val[0], val[1] ]
                     }
-                | p_args_head tSTAR tIDENTIFIER tCOMMA p_args_post
+                | p_args_head p_rest tCOMMA p_args_post
                     {
-                      match_rest = @builder.match_rest(val[1], val[2])
-                      result = [ *val[0], match_rest, *val[4] ]
-                    }
-                | p_args_head tSTAR
-                    {
-                      result = [ *val[0], @builder.match_rest(val[1]) ]
-                    }
-                | p_args_head tSTAR tCOMMA p_args_post
-                    {
-                      result = [ *val[0], @builder.match_rest(val[1]), *val[3] ]
+                      result = [ *val[0], val[1], *val[3] ]
                     }
                 | p_args_tail
 
@@ -2178,6 +2168,11 @@ opt_block_args_tail:
           p_rest: tSTAR tIDENTIFIER
                     {
                       result = @builder.match_rest(val[0], val[1])
+                    }
+                | tSTAR nonlocal_var
+                    {
+                      non_lvar = @builder.accessible(val[1])
+                      result = @builder.match_rest(val[0], non_lvar)
                     }
                 | tSTAR
                     {
@@ -2302,6 +2297,11 @@ opt_block_args_tail:
       p_variable: tIDENTIFIER
                     {
                       result = @builder.assignable(@builder.match_var(val[0]))
+                    }
+                | nonlocal_var
+                    {
+                      non_lvar = @builder.accessible(val[0])
+                      result = @builder.assignable(@builder.match_var(non_lvar))
                     }
 
        p_var_ref: tCARET tIDENTIFIER

--- a/test/ruby-next/test_parser.rb
+++ b/test/ruby-next/test_parser.rb
@@ -164,4 +164,117 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_NEXT)
   end
+
+  def test_pattern_matching_match_ivars
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:match_as,
+          s(:int, 1),
+          s(:match_var, s(:ivar, :@a))),
+        nil,
+        s(:true)),
+      %q{in 1 => @a then true},
+      %q{   ~~~~~~~ expression (in_pattern.match_as)
+        |     ~~ operator (in_pattern.match_as)},
+      SINCE_NEXT
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_var, s(:ivar, :@a)),
+          s(:match_var, s(:ivar, :@c))),
+        nil,
+        s(:true)),
+        %q{in @a, @c then true},
+       %q{},
+       SINCE_NEXT
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_var, s(:ivar, :@a)),
+          s(:match_rest, s(:match_var, s(:ivar, :@b))),
+          s(:match_var, s(:ivar, :@c))),
+        nil,
+        s(:true)),
+        %q{in @a, *@b, @c then true},
+       %q{},
+       SINCE_NEXT
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:const_pattern,
+          s(:const, nil, :A),
+          s(:array_pattern,
+            s(:match_var, s(:ivar, :@i)),
+            s(:match_rest, s(:match_var, s(:ivar, :@j))),
+            s(:match_var, s(:ivar, :@k)))),
+        nil,
+        s(:true)),
+      %q{in A(@i, *@j, @k) then true},
+      %q{},
+      SINCE_NEXT
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:pair,
+            s(:sym, :a),
+            s(:match_var,
+              s(:ivar, :@a)))),
+        nil,
+        s(:true)),
+        %q{in a: @a then true},
+      %q{},
+      SINCE_NEXT
+    )
+  end
+
+  def test_pattern_matching_match_gvars
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:match_as,
+          s(:int, 1),
+          s(:match_var, s(:gvar, :$a))),
+        nil,
+        s(:true)),
+      %q{in 1 => $a then true},
+      %q{   ~~~~~~~ expression (in_pattern.match_as)
+        |     ~~ operator (in_pattern.match_as)},
+      SINCE_NEXT
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:const_pattern,
+          s(:const, nil, :A),
+          s(:array_pattern,
+            s(:match_var, s(:gvar, :$i)),
+            s(:match_rest, s(:match_var, s(:gvar, :$j))),
+            s(:match_var, s(:gvar, :$k)))),
+        nil,
+        s(:true)),
+      %q{in A($i, *$j, $k) then true},
+      %q{},
+      SINCE_NEXT
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:pair,
+            s(:sym, :a),
+            s(:match_var,
+              s(:gvar, :$b)))),
+        nil,
+        s(:true)),
+        %q{in a: $b then true},
+      %q{},
+      SINCE_NEXT
+    )
+  end
 end


### PR DESCRIPTION
Proposed in https://bugs.ruby-lang.org/issues/18408
